### PR TITLE
fix: rename SessionAssistantID to SessionAgentID

### DIFF
--- a/go/dto.go
+++ b/go/dto.go
@@ -12,11 +12,7 @@ type SessionCreateRequest struct {
 }
 
 type SessionAgentID struct {
-	AgentId int64 `json:"agent_id"`
-}
-
-type SessionAssistantID struct {
-	AssistantId int64 `json:"assistant_id"`
+	AgentID int64 `json:"agent_id"`
 }
 
 type SessionHistory struct {

--- a/go/dto.go
+++ b/go/dto.go
@@ -7,12 +7,16 @@ import (
 
 type SessionCreateRequest struct {
 	SessionHistory
-	SessionAssistantID
+	SessionAgentID
 	ClientDataBody
 }
 
+type SessionAgentID struct {
+	AgentId int64 `json:"agent_id"`
+}
+
 type SessionAssistantID struct {
-	AssistantId int `json:"assistant_id"`
+	AssistantId int64 `json:"assistant_id"`
 }
 
 type SessionHistory struct {
@@ -48,7 +52,7 @@ type ClientDataBody struct {
 type OneShotRequest struct {
 	SendMessageBody
 	SessionHistory
-	SessionAssistantID
+	SessionAgentID
 	SeedSession string `json:"seed_session,omitempty" form:"seed_session" validate:"omitempty,uuid"`
 }
 

--- a/go/message.go
+++ b/go/message.go
@@ -167,7 +167,7 @@ func (s *Client) OneShot(ctx context.Context, request OneShotRequest) (*SendMess
 		}
 	}
 
-	if err := writer.WriteField("agent_id", fmt.Sprintf("%d", request.AgentId)); err != nil {
+	if err := writer.WriteField("agent_id", fmt.Sprintf("%d", request.AgentID)); err != nil {
 		return nil, err
 	}
 

--- a/go/message.go
+++ b/go/message.go
@@ -166,7 +166,8 @@ func (s *Client) OneShot(ctx context.Context, request OneShotRequest) (*SendMess
 			return nil, err
 		}
 	}
-	if err := writer.WriteField("assistant_id", fmt.Sprintf("%d", request.AssistantId)); err != nil {
+
+	if err := writer.WriteField("agent_id", fmt.Sprintf("%d", request.AgentId)); err != nil {
 		return nil, err
 	}
 

--- a/go/message_test.go
+++ b/go/message_test.go
@@ -28,7 +28,7 @@ func TestSendMessage(t *testing.T) {
 
 	resCreateSession, err := client.CreateSession(context.Background(), verbeux.SessionCreateRequest{
 		SessionAgentID: verbeux.SessionAgentID{
-			AgentId: 865,
+			AgentID: 865,
 		},
 	})
 	require.NoError(t, err)
@@ -58,7 +58,7 @@ func TestSendMessageAudio(t *testing.T) {
 
 	resCreateSession, err := client.CreateSession(context.Background(), verbeux.SessionCreateRequest{
 		SessionAgentID: verbeux.SessionAgentID{
-			AgentId: 865,
+			AgentID: 865,
 		},
 	})
 
@@ -96,7 +96,7 @@ func TestSendMessageImage(t *testing.T) {
 
 	resCreateSession, err := client.CreateSession(context.Background(), verbeux.SessionCreateRequest{
 		SessionAgentID: verbeux.SessionAgentID{
-			AgentId: 865,
+			AgentID: 865,
 		},
 	})
 
@@ -144,7 +144,7 @@ func TestSendMessageOneShot(t *testing.T) {
 
 	result, err := client.OneShot(context.Background(), verbeux.OneShotRequest{
 		SessionAgentID: verbeux.SessionAgentID{
-			AgentId: 865,
+			AgentID: 865,
 		},
 		SendMessageBody: verbeux.SendMessageBody{
 			Message: "oq tem na imagem?",

--- a/go/message_test.go
+++ b/go/message_test.go
@@ -27,8 +27,8 @@ func TestSendMessage(t *testing.T) {
 	)
 
 	resCreateSession, err := client.CreateSession(context.Background(), verbeux.SessionCreateRequest{
-		SessionAssistantID: verbeux.SessionAssistantID{
-			AssistantId: 865,
+		SessionAgentID: verbeux.SessionAgentID{
+			AgentId: 865,
 		},
 	})
 	require.NoError(t, err)
@@ -57,8 +57,8 @@ func TestSendMessageAudio(t *testing.T) {
 	)
 
 	resCreateSession, err := client.CreateSession(context.Background(), verbeux.SessionCreateRequest{
-		SessionAssistantID: verbeux.SessionAssistantID{
-			AssistantId: 865,
+		SessionAgentID: verbeux.SessionAgentID{
+			AgentId: 865,
 		},
 	})
 
@@ -95,8 +95,8 @@ func TestSendMessageImage(t *testing.T) {
 	)
 
 	resCreateSession, err := client.CreateSession(context.Background(), verbeux.SessionCreateRequest{
-		SessionAssistantID: verbeux.SessionAssistantID{
-			AssistantId: 865,
+		SessionAgentID: verbeux.SessionAgentID{
+			AgentId: 865,
 		},
 	})
 
@@ -143,8 +143,8 @@ func TestSendMessageOneShot(t *testing.T) {
 	}
 
 	result, err := client.OneShot(context.Background(), verbeux.OneShotRequest{
-		SessionAssistantID: verbeux.SessionAssistantID{
-			AssistantId: 865,
+		SessionAgentID: verbeux.SessionAgentID{
+			AgentId: 865,
 		},
 		SendMessageBody: verbeux.SendMessageBody{
 			Message: "oq tem na imagem?",


### PR DESCRIPTION
SessionAgentID replaces SessionAssistantID in SessionCreateRequest and OneShotRequest. Form field changed from assistant_id to agent_id. Tests updated to use AgentId.